### PR TITLE
Add Engagement Blitz Apify Skool scanner/poster actor

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -1,0 +1,13 @@
+{
+  "actorSpecification": 1,
+  "name": "engagement-blitz-skool-actor",
+  "title": "Engagement Blitz Skool Scanner/Poster",
+  "description": "Scans newest Skool posts/comments and optionally posts replies using authenticated session cookies.",
+  "version": "0.1",
+  "buildTag": "latest",
+  "meta": {
+    "templateId": "js-playwright-chrome"
+  },
+  "dockerfile": "./Dockerfile",
+  "input": "./input_schema.json"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM apify/actor-node-playwright-chrome:20
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . ./
+
+CMD ["npm", "start"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,18 @@
-(MIT License)
+Copyright (c) 2026 GlobalMarketingAdvocates
+All rights reserved.
 
-Copyright (C) 2016 Thomas Friese, http://tasmo.rocks
+This software and associated files (the "Software") are proprietary and confidential.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is NOT granted to any person or entity to use, copy, modify, merge, publish,
+distribute, sublicense, sell, lease, host, reverse engineer, or create derivative works
+from the Software, in whole or in part, for any purpose, without prior explicit written
+permission from the copyright holder.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+Any unauthorized use is strictly prohibited.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT, OR
+OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ npm start
 - Keep `maxPostsToCheck` between **5 and 10** for cheapest runs.
 - Cookie freshness is critical; expired session cookies will fail authentication.
 - Skool DOM can change; selectors in `src/main.js` are intentionally flexible but may need updates over time.
+## License
+
+Proprietary - All rights reserved. No permission is granted to use, copy, modify, or distribute this code without explicit written permission from the owner. See `LICENSE`.
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,79 @@
-# Your GitHub Learning Lab Repository for Introducing GitHub
+# Engagement Blitz Skool Actor (Apify + Playwright + Chrome)
 
-Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.
+Lightweight Apify actor for **Skool scanning and posting** using authenticated session cookies.
 
-Oh! I haven't introduced myself...
+## What this actor does
 
-I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey to learn and master the various topics covered in this course. I will be using Issue and Pull Request comments to communicate with you. In fact, I already added an issue for you to check out.
+- Uses **Playwright + Chrome** (Apify Playwright Chrome base image).
+- Accepts Skool **session cookies** and opens a group while authenticated.
+- Scans only the latest posts/comments (bounded by `maxPostsToCheck`) for low-cost runs.
+- Detects:
+  - new posts
+  - new comments
+  - mentions of `targetUsername`
+  - optional Blitz tab scan (`scanBlitzTab`)
+- Extracts minimal fields:
+  - `postId`, `commentId`, `author`, `text`, `timestamp`, `url`, `mentions`
+- Stores last-seen post/comment IDs in Apify Key-Value Store to avoid duplicates.
+- Sends JSON to your `webhookUrl` (Pabbly).
+- Supports second mode (`post`) for posting a reply/comment with same session cookies.
 
-![issue tab](https://lab.github.com/public/images/issue_tab.png)
+> No AI, GIF, or content-generation logic is included.
 
-I'll meet you over there, can't wait to get started!
+## Files
 
-This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+- `src/main.js` - actor logic (scan + post modes)
+- `input_schema.json` - Apify input schema
+- `.actor/actor.json` - actor metadata
+- `Dockerfile` - Apify build image and startup command
+- `examples/input.scan.json` - sample scan input
+- `examples/input.post.json` - sample post input
+- `examples/webhook.payload.scan.json` - sample scan webhook output
+- `examples/webhook.payload.post.json` - sample post webhook output
+
+## Input schema fields
+
+- `groupUrl`
+- `cookies`
+- `targetUsername`
+- `maxPostsToCheck`
+- `scanMentionsOnly`
+- `scanComments`
+- `scanBlitzTab`
+- `webhookUrl`
+- `mode` (`scan` or `post`)
+- `replyContent` (used when `mode=post`)
+- `postId` (used when `mode=post`)
+- `parentId` (optional metadata for threaded context)
+
+## Setup on Apify
+
+1. Create a new Actor in Apify.
+2. Upload this project (or connect GitHub repo).
+3. Ensure build uses included `Dockerfile`.
+4. In Actor input, paste JSON from:
+   - scan mode: `examples/input.scan.json`
+   - post mode: `examples/input.post.json`
+5. Run actor.
+6. Check dataset items and webhook receiver for payloads.
+
+## Local run
+
+```bash
+npm install
+npm start
+```
+
+Set input locally using Apify conventions, for example:
+
+```bash
+export APIFY_LOCAL_STORAGE_DIR=./apify_storage
+cp examples/input.scan.json ./apify_storage/key_value_stores/default/INPUT.json
+npm start
+```
+
+## Notes
+
+- Keep `maxPostsToCheck` between **5 and 10** for cheapest runs.
+- Cookie freshness is critical; expired session cookies will fail authentication.
+- Skool DOM can change; selectors in `src/main.js` are intentionally flexible but may need updates over time.

--- a/examples/input.post.json
+++ b/examples/input.post.json
@@ -1,0 +1,18 @@
+{
+  "mode": "post",
+  "groupUrl": "https://www.skool.com/your-group",
+  "cookies": [
+    {
+      "name": "_skool_session",
+      "value": "YOUR_SESSION_COOKIE",
+      "domain": ".skool.com",
+      "path": "/",
+      "httpOnly": true,
+      "secure": true
+    }
+  ],
+  "postId": "abc123",
+  "parentId": "optional-parent-comment-id",
+  "replyContent": "Thanks for the post — great point!",
+  "webhookUrl": "https://connect.pabbly.com/workflow/sendwebhookdata/IXXXXXXX"
+}

--- a/examples/input.scan.json
+++ b/examples/input.scan.json
@@ -1,0 +1,20 @@
+{
+  "mode": "scan",
+  "groupUrl": "https://www.skool.com/your-group",
+  "cookies": [
+    {
+      "name": "_skool_session",
+      "value": "YOUR_SESSION_COOKIE",
+      "domain": ".skool.com",
+      "path": "/",
+      "httpOnly": true,
+      "secure": true
+    }
+  ],
+  "targetUsername": "jane_doe",
+  "maxPostsToCheck": 8,
+  "scanMentionsOnly": false,
+  "scanComments": true,
+  "scanBlitzTab": false,
+  "webhookUrl": "https://connect.pabbly.com/workflow/sendwebhookdata/IXXXXXXX"
+}

--- a/examples/webhook.payload.post.json
+++ b/examples/webhook.payload.post.json
@@ -1,0 +1,9 @@
+{
+  "mode": "post",
+  "ok": true,
+  "groupUrl": "https://www.skool.com/your-group",
+  "postId": "abc123",
+  "parentId": "optional-parent-comment-id",
+  "replyContent": "Thanks for the post — great point!",
+  "postedAt": "2026-05-21T00:00:00.000Z"
+}

--- a/examples/webhook.payload.scan.json
+++ b/examples/webhook.payload.scan.json
@@ -1,0 +1,18 @@
+{
+  "mode": "scan",
+  "groupUrl": "https://www.skool.com/your-group",
+  "scannedAt": "2026-05-21T00:00:00.000Z",
+  "totalNewEvents": 2,
+  "events": [
+    {
+      "type": "new_post",
+      "postId": "post_123",
+      "commentId": null,
+      "author": "John Doe",
+      "text": "Welcome @jane_doe to the group!",
+      "timestamp": "2026-05-21T00:00:00.000Z",
+      "url": "https://www.skool.com/your-group/post/post_123",
+      "mentions": ["jane_doe"]
+    }
+  ]
+}

--- a/input_schema.json
+++ b/input_schema.json
@@ -1,0 +1,87 @@
+{
+  "title": "Engagement Blitz Skool Scanner/Poster Input",
+  "type": "object",
+  "version": 1,
+  "schemaVersion": 1,
+  "properties": {
+    "groupUrl": {
+      "title": "Skool Group URL",
+      "type": "string",
+      "description": "Full URL of the Skool group feed page.",
+      "editor": "textfield"
+    },
+    "cookies": {
+      "title": "Session Cookies",
+      "type": "array",
+      "description": "Array of Playwright cookie objects for authenticated Skool access.",
+      "editor": "json",
+      "prefill": [
+        {
+          "name": "_skool_session",
+          "value": "YOUR_SESSION_COOKIE",
+          "domain": ".skool.com",
+          "path": "/",
+          "httpOnly": true,
+          "secure": true
+        }
+      ]
+    },
+    "targetUsername": {
+      "title": "Target Username",
+      "type": "string",
+      "description": "Username to detect in mentions (without @ is fine).",
+      "editor": "textfield"
+    },
+    "maxPostsToCheck": {
+      "title": "Max Posts To Check",
+      "type": "integer",
+      "description": "Number of newest posts to inspect.",
+      "default": 8,
+      "minimum": 1,
+      "maximum": 20
+    },
+    "scanMentionsOnly": {
+      "title": "Scan Mentions Only",
+      "type": "boolean",
+      "default": false
+    },
+    "scanComments": {
+      "title": "Scan Comments",
+      "type": "boolean",
+      "default": true
+    },
+    "scanBlitzTab": {
+      "title": "Scan Blitz Tab/Category",
+      "type": "boolean",
+      "default": false
+    },
+    "webhookUrl": {
+      "title": "Webhook URL",
+      "type": "string",
+      "description": "Pabbly webhook endpoint for outgoing JSON.",
+      "editor": "textfield"
+    },
+    "mode": {
+      "title": "Mode",
+      "type": "string",
+      "enum": ["scan", "post"],
+      "default": "scan"
+    },
+    "replyContent": {
+      "title": "Reply Content",
+      "type": "string",
+      "description": "Comment text to post when mode=post."
+    },
+    "postId": {
+      "title": "Post ID",
+      "type": "string",
+      "description": "Target post ID when mode=post."
+    },
+    "parentId": {
+      "title": "Parent ID",
+      "type": "string",
+      "description": "Optional parent comment ID for threaded replies."
+    }
+  },
+  "required": ["groupUrl", "cookies", "mode"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "engagement-blitz-skool-actor",
+  "version": "1.0.0",
+  "description": "Lightweight Apify actor for scanning and posting in Skool groups",
+  "type": "module",
+  "scripts": {
+    "start": "node src/main.js",
+    "test": "node --check src/main.js"
+  },
+  "dependencies": {
+    "apify": "^3.1.10",
+    "playwright": "^1.54.0"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,201 @@
+import { Actor, log } from 'apify';
+import { chromium } from 'playwright';
+
+await Actor.init();
+
+const input = await Actor.getInput() ?? {};
+const {
+  groupUrl,
+  cookies = [],
+  targetUsername = '',
+  maxPostsToCheck = 8,
+  scanMentionsOnly = false,
+  scanComments = true,
+  scanBlitzTab = false,
+  webhookUrl,
+  mode = 'scan',
+  replyContent,
+  postId,
+  parentId,
+} = input;
+
+if (!groupUrl) throw new Error('groupUrl is required.');
+if (!Array.isArray(cookies) || cookies.length === 0) throw new Error('cookies must be a non-empty array.');
+if (!['scan', 'post'].includes(mode)) throw new Error('mode must be scan or post.');
+if (mode === 'post' && (!replyContent || !postId)) throw new Error('post mode requires replyContent and postId.');
+
+const kv = await Actor.openKeyValueStore();
+const stateKey = `state:${groupUrl}`;
+const state = (await kv.getValue(stateKey)) || { lastSeenPostIds: [], lastSeenCommentIds: [] };
+const knownPostIds = new Set(state.lastSeenPostIds || []);
+const knownCommentIds = new Set(state.lastSeenCommentIds || []);
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext();
+await context.addCookies(cookies);
+const page = await context.newPage();
+
+const normalizeUsername = (name) => name?.toLowerCase().replace(/^@/, '');
+const target = normalizeUsername(targetUsername);
+
+const extractIdFromEl = async (locator, fallbackPrefix) => {
+  const idFromAttr = await locator.getAttribute('data-id');
+  if (idFromAttr) return idFromAttr;
+  const href = await locator.locator('a[href*="/post/"]').first().getAttribute('href').catch(() => null);
+  if (href) return href.split('/').filter(Boolean).pop();
+  return `${fallbackPrefix}-${Math.random().toString(36).slice(2, 9)}`;
+};
+
+const parseMentions = (text) => {
+  const mentions = [...text.matchAll(/@([a-zA-Z0-9_\-.]+)/g)].map((m) => m[1]);
+  return [...new Set(mentions)];
+};
+
+const shouldKeep = (item) => {
+  if (!scanMentionsOnly) return true;
+  if (!target) return false;
+  return item.mentions.map(normalizeUsername).includes(target);
+};
+
+const sendWebhook = async (payload) => {
+  if (!webhookUrl) return;
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`Webhook failed (${res.status}).`);
+};
+
+const gotoGroup = async () => {
+  await page.goto(groupUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+  await page.waitForTimeout(1500);
+  if (scanBlitzTab) {
+    const blitz = page.getByRole('tab', { name: /blitz/i }).first();
+    if (await blitz.isVisible().catch(() => false)) {
+      await blitz.click();
+      await page.waitForTimeout(1200);
+    }
+  }
+};
+
+const postReply = async () => {
+  await gotoGroup();
+  const postLink = page.locator(`a[href*="/post/${postId}"]`).first();
+  await postLink.scrollIntoViewIfNeeded();
+  await postLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const inputBox = page.locator('textarea, [contenteditable="true"]').first();
+  await inputBox.click();
+  await inputBox.fill(replyContent);
+
+  const submit = page.getByRole('button', { name: /post|reply|comment/i }).first();
+  await submit.click();
+  await page.waitForTimeout(1200);
+
+  const result = {
+    mode: 'post',
+    ok: true,
+    groupUrl,
+    postId,
+    parentId: parentId || null,
+    replyContent,
+    postedAt: new Date().toISOString(),
+  };
+
+  await Actor.pushData(result);
+  await sendWebhook(result);
+};
+
+const scan = async () => {
+  await gotoGroup();
+
+  const posts = page.locator('article, [data-post-id], .post-item');
+  const count = Math.min(await posts.count(), maxPostsToCheck);
+  const events = [];
+
+  for (let i = 0; i < count; i++) {
+    const post = posts.nth(i);
+    const postIdVal = (await post.getAttribute('data-post-id')) || await extractIdFromEl(post, 'post');
+    if (knownPostIds.has(postIdVal)) continue;
+
+    const postText = (await post.innerText()).trim();
+    const postMentions = parseMentions(postText);
+    const author = (await post.locator('[data-author], .author, a[href*="/u/"]').first().innerText().catch(() => ''))?.trim();
+    const postUrl = await post.locator('a[href*="/post/"]').first().getAttribute('href').catch(() => null);
+    const timestamp = await post.locator('time').first().getAttribute('datetime').catch(() => new Date().toISOString());
+
+    const postEvent = {
+      type: 'new_post',
+      postId: postIdVal,
+      commentId: null,
+      author,
+      text: postText,
+      timestamp,
+      url: postUrl ? new URL(postUrl, groupUrl).toString() : groupUrl,
+      mentions: postMentions,
+    };
+
+    if (shouldKeep(postEvent)) events.push(postEvent);
+    knownPostIds.add(postIdVal);
+
+    if (!scanComments) continue;
+
+    const comments = post.locator('[data-comment-id], .comment-item');
+    const commentCount = Math.min(await comments.count(), 5);
+
+    for (let j = 0; j < commentCount; j++) {
+      const comment = comments.nth(j);
+      const commentIdVal = (await comment.getAttribute('data-comment-id')) || await extractIdFromEl(comment, 'comment');
+      if (knownCommentIds.has(commentIdVal)) continue;
+
+      const commentText = (await comment.innerText()).trim();
+      const commentMentions = parseMentions(commentText);
+      const commentAuthor = (await comment.locator('[data-author], .author, a[href*="/u/"]').first().innerText().catch(() => ''))?.trim();
+      const commentUrl = await comment.locator('a[href*="comment"], a[href*="/post/"]').first().getAttribute('href').catch(() => postUrl);
+      const commentTimestamp = await comment.locator('time').first().getAttribute('datetime').catch(() => new Date().toISOString());
+
+      const commentEvent = {
+        type: 'new_comment',
+        postId: postIdVal,
+        commentId: commentIdVal,
+        author: commentAuthor,
+        text: commentText,
+        timestamp: commentTimestamp,
+        url: commentUrl ? new URL(commentUrl, groupUrl).toString() : groupUrl,
+        mentions: commentMentions,
+      };
+
+      if (shouldKeep(commentEvent)) events.push(commentEvent);
+      knownCommentIds.add(commentIdVal);
+    }
+  }
+
+  const output = {
+    mode: 'scan',
+    groupUrl,
+    scannedAt: new Date().toISOString(),
+    totalNewEvents: events.length,
+    events,
+  };
+
+  await kv.setValue(stateKey, {
+    lastSeenPostIds: Array.from(knownPostIds).slice(-200),
+    lastSeenCommentIds: Array.from(knownCommentIds).slice(-500),
+    updatedAt: new Date().toISOString(),
+  });
+
+  await Actor.pushData(output);
+  await sendWebhook(output);
+};
+
+try {
+  if (mode === 'post') await postReply();
+  else await scan();
+} finally {
+  await page.close();
+  await context.close();
+  await browser.close();
+  await Actor.exit();
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, cost-conscious Apify Actor for Engagement Blitz that replaces expensive third-party Skool actors by using `Playwright + Chrome` and scanning only the newest items.
- Support both a low-cost `scan` mode (detect new posts/comments/mentions and optional Blitz tab) and a `post` mode (reply/comment) using the same authenticated session cookies.

### Description
- Added a complete Apify actor scaffold including `.actor/actor.json`, `Dockerfile`, `package.json`, `input_schema.json`, examples, and README for deployment and local runs. 
- Implemented main runtime in `src/main.js` that authenticates via provided `cookies`, opens `groupUrl`, inspects up to `maxPostsToCheck` newest posts, optionally scans comments and Blitz tab, and detects `new_post`, `new_comment`, and mentions of `targetUsername`. 
- Extracts minimal fields (`postId`, `commentId`, `author`, `text`, `timestamp`, `url`, `mentions`), persists last-seen IDs in Apify Key-Value Store to avoid duplicates, and sends clean JSON payloads to `webhookUrl` (Pabbly). 
- Added a `post` action that navigates to the target `postId` and submits `replyContent`; included example input and webhook/posting payload files in `examples/`.

### Testing
- Ran `node --check src/main.js` which succeeded and validated basic syntax. 
- Attempted `npm install` in this environment but it failed with `403 Forbidden` fetching `apify` from the npm registry, so dependency installation and runtime verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f22904df0832da0fa29bf5a00c199)